### PR TITLE
Adding babel to transpile forEachVariation with build step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": ["airbnb"],
+  "plugins": [
+    ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
+    ["add-module-exports"]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Ignore top-level built files
+/forEachVariation.js
+
 # Runtime data
 pids
 *.pid

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "react-component-variations": "./bin.js"
   },
   "scripts": {
-    "lint": "eslint .",
+    "prebuild": "npm run clean",
+    "build": "babel src -d .",
+    "build:watch": "npm run build -- --watch",
+    "clean": "rimraf forEachVariation.js",
+    "lint": "eslint --ext=js,jsx src",
+    "prepublish": "npm run build",
     "pretest": "npm run lint",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -18,13 +23,19 @@
     "chalk": "^2.4.0",
     "glob": "^7.1.2",
     "jsonschema": "^1.2.4",
+    "object.assign": "^4.1.0",
     "object.entries": "^1.0.4",
     "resolve": "^1.7.1",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-replace-object-assign": "^1.0.0",
+    "babel-preset-airbnb": "^2.4.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.11.0"
+    "eslint-plugin-import": "^2.11.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/forEachVariation.js
+++ b/src/forEachVariation.js
@@ -67,7 +67,7 @@ module.exports = function forEachVariation(descriptor, consumer, callback) {
       createdAt && { createdAt },
       typeof noVisualSignificance === 'boolean' && { noVisualSignificance },
       variation,
-      { options, metadata, render }
+      { options, metadata, render },
     );
     callback(newVariation);
   });


### PR DESCRIPTION
### Overview
We want `forEachVariation` to work in-browser, so we need to transpile it with babel the way we do all of our JS. This PR adds a build step that just transpiles `forEachVariation.js`, as `bin.js` and `validate.js` will be running in node. We can lint and transpile those as well, but that can be an independent decision and PR.

#### Build location + exporting
We were exporting in a way such that consumers can `import forEachVariation from 'react-component-variations/forEachVariation`. I think a cleaner setup would be something like `import forEachVariation from 'react-component-variations/lib/forEachVariation'` or `import { forEachVariation } from 'react-component-variations'`. This would also make allow us to transpile to a non-root directory. I might also just be missing an approach that gives us the best of both worlds.

Tested with Storybook in IE11.

@ljharb 