### PR TITLE
[Addition] Add access to project name in forEachVariation callback

### DIFF
--- a/src/traversal/forEachProjectVariation.js
+++ b/src/traversal/forEachProjectVariation.js
@@ -35,7 +35,7 @@ export default function forEachProjectVariation(consumer, {
         projectConfig,
         { getExtras, getDescriptor, projectRoot },
       )((descriptor) => {
-        forEachVariation(descriptor, consumer, callback);
+        forEachVariation({ projectName, ...descriptor }, consumer, callback);
       });
     });
   };

--- a/src/traversal/forEachVariation.js
+++ b/src/traversal/forEachVariation.js
@@ -8,12 +8,14 @@ export default function forEachVariation(descriptor, consumer, callback) {
 
   const {
     component,
+    projectName,
     createdAt: rootCreatedAt,
     usage,
     options: allRootConsumerOptions = {},
     metadata = {},
     variations,
   } = descriptor;
+
   const { [consumer]: rootConsumerOptions = {} } = allRootConsumerOptions || {};
 
   // this consumer is disabled
@@ -45,6 +47,7 @@ export default function forEachVariation(descriptor, consumer, callback) {
 
     const newVariation = {
       componentName,
+      projectName,
       title,
       component,
       usage,

--- a/test/traversal/forEachProjectVariation.js
+++ b/test/traversal/forEachProjectVariation.js
@@ -66,8 +66,8 @@ describe('forEachProjectVariation', () => {
     expect(forEachVariation).toHaveBeenCalledTimes(mockProjectNames.length);
     const { calls } = forEachVariation.mock;
 
-    calls.forEach((args) => {
-      expect(args).toEqual([mockDescriptor, consumer, callback]);
+    calls.forEach((args, idx) => {
+      expect(args).toEqual([{ projectName: mockProjectNames[idx], ...mockDescriptor }, consumer, callback]);
     });
   });
 });

--- a/test/traversal/forEachVariation.js
+++ b/test/traversal/forEachVariation.js
@@ -1,7 +1,30 @@
 import forEachVariation from '../../src/traversal/forEachVariation';
 
+const mockDescriptor = {
+  component: 'mock-component',
+  projectName: 'mock-project',
+  createdAt: 'timestamp',
+  usage: 'mock-usage',
+  metadata: { foo: 'bar' },
+  variations: [],
+};
+
 describe('forEachVariation', () => {
   it('is a function', () => {
     expect(typeof forEachVariation).toBe('function');
+  });
+
+  describe('callback function', () => {
+    it('passes in the correct mockDescriptor data', () => {
+      const callback = (newVariation) => {
+        Object.keys(mockDescriptor).forEach((property) => {
+          if (property === 'variations') {
+            return;
+          }
+          expect(mockDescriptor[property]).toEqual(newVariation[property]);
+        });
+      };
+      forEachVariation(mockDescriptor, {}, callback);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Adds the ability to access the projectName property in the `forEachVariation` callback. 

## How was it tested?
@ljharb - I would like to add tests in `forEachProjectVariation` or `forEachVariation`, but it seems as though the method is pretty much completely stubbed out. I tested by linking with my own project, and I had access to the property, but I can also add unit testing here if you would like!

## Reviewers
@maja @ljharb 

