### PR TITLE
[Bugfix] Fix off-by-one in stripMatchingPrefix and refactor into utils

### DIFF
--- a/src/helpers/stripMatchingPrefix.js
+++ b/src/helpers/stripMatchingPrefix.js
@@ -1,0 +1,9 @@
+import path from 'path';
+
+function stripExtension(actualPath) {
+  return path.join(path.dirname(actualPath), path.basename(actualPath, path.extname(actualPath)));
+}
+
+export default function stripMatchingPrefix(prefix, toStrip) {
+  return stripExtension(toStrip.startsWith(prefix) ? toStrip.slice(prefix.length) : toStrip);
+}

--- a/src/traversal/forEachDescriptor.js
+++ b/src/traversal/forEachDescriptor.js
@@ -12,7 +12,7 @@ function stripExtension(actualPath) {
 }
 
 function stripMatchingPrefix(prefix, toStrip) {
-  return stripExtension(toStrip.startsWith(prefix) ? toStrip.slice(prefix.length + 1) : toStrip);
+  return stripExtension(toStrip.startsWith(prefix) ? toStrip.slice(prefix.length) : toStrip);
 }
 
 export default function forEachDescriptor(

--- a/src/traversal/forEachDescriptor.js
+++ b/src/traversal/forEachDescriptor.js
@@ -6,14 +6,7 @@ import validateProject from '../helpers/validateProject';
 import getComponents from '../helpers/getComponents';
 import getVariationProviders from '../helpers/getVariationProviders';
 import getDescriptorFromProvider from '../helpers/getDescriptorFromProvider';
-
-function stripExtension(actualPath) {
-  return path.join(path.dirname(actualPath), path.basename(actualPath, path.extname(actualPath)));
-}
-
-function stripMatchingPrefix(prefix, toStrip) {
-  return stripExtension(toStrip.startsWith(prefix) ? toStrip.slice(prefix.length) : toStrip);
-}
+import stripMatchingPrefix from '../helpers/stripMatchingPrefix';
 
 export default function forEachDescriptor(
   projectConfig,

--- a/test/helpers/stripMatchingPrefix.js
+++ b/test/helpers/stripMatchingPrefix.js
@@ -1,0 +1,9 @@
+import stripMatchingPrefix from '../../src/helpers/stripMatchingPrefix';
+
+describe('stripMatchingPrefix', () => {
+  it('correctly strips toStrip prefix', () => {
+    const toStrip = '/Users/foo/bar/baz/buzz/bang/quox/stories/a/b/c/dvariationProvider.jsx';
+    const prefix = '/Users/foo/bar/baz/buzz/bang/quox/stories/';
+    expect(stripMatchingPrefix(prefix, toStrip)).toEqual('a/b/c/dvariationProvider');
+  });
+});

--- a/test/traversal/forEachDescriptor.js
+++ b/test/traversal/forEachDescriptor.js
@@ -124,8 +124,8 @@ describe('forEachDescriptor', () => {
         variations: './to/variations/**',
       };
 
-      const variationPathA = `${projectRoot}/${variationsRoot}/path/to/a`;
-      const variationPathB = `${projectRoot}/${variationsRoot}/path/to/b`;
+      const variationPathA = `${projectRoot}/${variationsRoot}path/to/a`;
+      const variationPathB = `${projectRoot}/${variationsRoot}path/to/b`;
 
       mockVariations = {
         [variationPathA]: {


### PR DESCRIPTION
Fix an off-by-one error in the stripMatchingPrefix function, refactor into utils, and add test. 