### PR TITLE
[addition] Add hierarchy to forEachVariation

### DIFF
--- a/src/traversal/forEachVariation.js
+++ b/src/traversal/forEachVariation.js
@@ -9,6 +9,7 @@ export default function forEachVariation(descriptor, consumer, callback) {
   const {
     component,
     projectName,
+    variationProvider,
     createdAt: rootCreatedAt,
     usage,
     options: allRootConsumerOptions = {},
@@ -47,6 +48,7 @@ export default function forEachVariation(descriptor, consumer, callback) {
 
     const newVariation = {
       componentName,
+      variationProvider,
       projectName,
       title,
       component,

--- a/test/traversal/forEachVariation.js
+++ b/test/traversal/forEachVariation.js
@@ -48,7 +48,6 @@ describe('forEachVariation', () => {
         rootOptions: mockDescriptor.options,
       };
       delete expectedDescriptor.variations;
-      delete expectedDescriptor.variationProvider;
 
       const callback = jest.fn((newVariation) => {
         expect(newVariation).toEqual(expectedDescriptor);


### PR DESCRIPTION
Gives consumers of `forEachProjectVariation` access to the hierarchy property, which contains either the path from the base, or the path from the variationsRoot (as described in the package.json) to the variationProvider in which the variation is described. 