### PR TITLE
[Bug] Fix validate.js variationsRoot bug

### DIFF
--- a/src/helpers/getValidationErrors.js
+++ b/src/helpers/getValidationErrors.js
@@ -1,5 +1,6 @@
-import path from 'path';
 import has from 'has';
+import values from 'object.values';
+
 import { validate } from 'jsonschema';
 import schema from '../schema.json';
 import getProjectExtras from './getProjectExtras';
@@ -105,19 +106,17 @@ export default function getValidationErrors(variations, {
   projectRoot,
 }) {
   const origError = console.error;
-  return variations.map((file) => {
+  return values(variations).map(({ actualPath, Module }) => {
     console.error = function throwError(msg) { throw new Error(msg); };
     try {
-      // eslint-disable-next-line import/no-dynamic-require, global-require
-      const module = require(path.join(process.cwd(), file));
-      validateDescriptorProvider(file, module.default || module, {
+      validateDescriptorProvider(actualPath, has(Module, 'default') ? Module.default : Module, {
         projectConfig,
         projectRoot,
       });
       console.error = origError;
       return null;
     } catch (e) {
-      return formatMsg(file, e.message);
+      return formatMsg(actualPath, e.message);
     }
   }).filter(Boolean);
 }

--- a/src/helpers/getVariationProviders.js
+++ b/src/helpers/getVariationProviders.js
@@ -12,7 +12,6 @@ export default function getVariationProviders(projectConfig, projectRoot, {
 } = {}) {
   validateProject(projectConfig);
 
-
   const {
     variations,
     variationsRoot,


### PR DESCRIPTION
`validate.js` was looking directly at the variations key in projectConfig, but this is a relativePath if `variationsRoot` is defined. This fix checks for the existance of `variationsRoot`, and if it exists, joins the path.