### PR TITLE
Move builder functions to a common helper

### DIFF
--- a/src/commands/componentPaths.js
+++ b/src/commands/componentPaths.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import path from 'path';
 import fromEntries from 'object.fromentries';
 import getComponentName from 'airbnb-prop-types/build/helpers/getComponentName';
-import has from 'has';
 
 import forEachProject from '../traversal/forEachProject';
 import forEachDescriptor from '../traversal/forEachDescriptor';
@@ -10,34 +9,13 @@ import getProjectRootConfig from '../helpers/getProjectRootConfig';
 import requireFiles from '../helpers/requireFiles';
 import getComponentPaths from '../helpers/getComponentPaths';
 import normalizeConfig from '../helpers/normalizeConfig';
-import validateProjects from '../helpers/validateProjects';
-import validateProject from '../helpers/validateProject';
 import stripMatchingPrefix from '../helpers/stripMatchingPrefix';
+import validateCommand from '../helpers/validateCommand';
 
 export const command = 'componentPaths';
 export const desc = 'print out component paths for the given project';
 
-export const builder = (yargs) => {
-  const config = normalizeConfig(yargs.argv);
-  const { project, projects, all } = config;
-  const allProjectNames = projects ? Object.keys(projects) : [];
-
-  if (all && allProjectNames.length <= 0) {
-    throw chalk.red('`--all` requires a non-empty “projects” config');
-  }
-  if (all && project) {
-    throw chalk.red('`--all` and `--project` are mutually exclusive');
-  }
-  if (project && !has(projects, project)) {
-    throw chalk.red(`Project "${project}" missing from “projects” config`);
-  }
-
-  if (projects) {
-    validateProjects(projects, allProjectNames, 'in the “projects” config');
-  } else {
-    validateProject(config);
-  }
-};
+export const builder = validateCommand();
 
 export const handler = (config) => {
   const projectRoot = process.cwd();

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -1,14 +1,12 @@
 import chalk from 'chalk';
-import has from 'has';
 
 import getComponents from '../helpers/getComponents';
 import getVariationProviders from '../helpers/getVariationProviders';
 import getValidationErrors from '../helpers/getValidationErrors';
 import requireFiles from '../helpers/requireFiles';
 import forEachProject from '../traversal/forEachProject';
-import validateProjects from '../helpers/validateProjects';
-import validateProject from '../helpers/validateProject';
 import normalizeConfig from '../helpers/normalizeConfig';
+import validateCommand from '../helpers/validateCommand';
 
 function getOverallErrors({
   variations = {},
@@ -55,27 +53,7 @@ function getOverallErrors({
 
 export const command = 'validate [variations]';
 export const desc = 'validate Variation Providers';
-export const builder = (yargs) => {
-  const config = normalizeConfig(yargs.argv);
-  const { project, projects, all } = config;
-  const allProjectNames = projects ? Object.keys(projects) : [];
-
-  if (all && allProjectNames.length <= 0) {
-    throw chalk.red('`--all` requires a non-empty “projects” config');
-  }
-  if (all && project) {
-    throw chalk.red('`--all` and `--project` are mutually exclusive');
-  }
-  if (project && !has(projects, project)) {
-    throw chalk.red(`Project "${project}" missing from “projects” config`);
-  }
-
-  if (projects) {
-    validateProjects(projects, allProjectNames, 'in the “projects” config');
-  } else {
-    validateProject(config);
-  }
-};
+export const builder = validateCommand;
 
 export const handler = (config) => {
   const projectRoot = process.cwd();

--- a/src/helpers/validateCommand.js
+++ b/src/helpers/validateCommand.js
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import has from 'has';
+
+import normalizeConfig from './normalizeConfig';
+import validateProjects from './validateProjects';
+import validateProject from './validateProject';
+
+export default function validateCommand(yargs) {
+  const config = normalizeConfig(yargs.argv);
+  const { project, projects, all } = config;
+  const allProjectNames = projects ? Object.keys(projects) : [];
+
+  if (all && allProjectNames.length <= 0) {
+    throw chalk.red('`--all` requires a non-empty “projects” config');
+  }
+  if (all && project) {
+    throw chalk.red('`--all` and `--project` are mutually exclusive');
+  }
+  if (project && !has(projects, project)) {
+    throw chalk.red(`Project "${project}" missing from “projects” config`);
+  }
+
+  if (projects) {
+    validateProjects(projects, allProjectNames, 'in the “projects” config');
+  } else {
+    validateProject(config);
+  }
+}


### PR DESCRIPTION
Move yargs builder functions to a shared helper. 

I'm not sure about the name, but it seems like this is doing a bunch of validation checks based on the config? so I called it `validateCommand`.