### PR TITLE
Use the babel cli option to copy uncompiled files in `src` to the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "babel src -d .",
-    "postbuild": "cp src/*.json ./",
+    "build": "babel src -d . --copy-files",
     "build:watch": "npm run build -- --watch",
     "clean": "rimraf *.js {commands,helpers,traversal} schema.json",
     "lint": "eslint --ext=js,jsx --ignore-path=.gitignore .",


### PR DESCRIPTION
Tiny change and the resulting built files are exactly the same. Using this option will make the watch script pick up changes to `src/schema.json`.