### PR TITLE
[regression] make sync hooks optional

### DIFF
--- a/src/projectConfig.js
+++ b/src/projectConfig.js
@@ -49,7 +49,9 @@ export default {
       type: 'object',
       properties: {
         hooks: { $ref: '#/definitions/require' },
+        additionalProperties: false,
       },
+      required: false,
     },
     rootDir: {
       type: 'string',

--- a/test/fixtures/projectConfig.json
+++ b/test/fixtures/projectConfig.json
@@ -1,0 +1,8 @@
+{
+  "foo": {
+    "componentsRoot": "./app/assets/javascripts/foo/team/",
+    "components": "./**/*.{jsx,tsx}",
+    "variationsRoot": "./app/assets/javascripts/foo/examples/",
+    "variations": "./**/*VariationProvider.{jsx,tsx}"
+  }
+}

--- a/test/helpers/validateProjects.js
+++ b/test/helpers/validateProjects.js
@@ -1,4 +1,5 @@
 import validateProjects from '../../src/helpers/validateProjects';
+import testProjectConfig from '../fixtures/projectConfig.json';
 
 describe('validateProjects', () => {
   it('throws when projectNames is not a non-empty array', () => {
@@ -20,5 +21,9 @@ describe('validateProjects', () => {
     expect(error).toMatchObject({
       message: expect.stringContaining(extraMsg),
     });
+  });
+
+  it('should pass on a valid projectConfig', () => {
+    expect(() => validateProjects(testProjectConfig, ['foo'])).not.toThrowError();
   });
 });


### PR DESCRIPTION
Make the `sync` field optional in the project config. 
+ Add a snapshot test for custom error message.