### PR TITLE
Add basic documentation to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,43 @@
 
 ⚠️ **Warning: this project is still very alpha**
 
+This project is:
+* A format called "variations" for specifying React component **_examples_** and providing **_documentation_** for them.
+* Tools for finding, validating, and iterating over variations.
+
+A variation looks like:
+
+```jsx
+// ButtonVariationProvider.jsx
+
+import React from 'react';
+import Button from '../components/Button';
+
+export default function ButtonVariationProvider({ action }) {
+  return {
+    component: Button,
+
+    usage: 'Buttons are things you click on!',
+
+    variations: [
+      {
+        title: 'Default',
+        render: () => <Button onClick={() => action('onClick')}>click me!</Button>,
+      },
+      {
+        title: 'Disabled',
+        render: () => <Button disabled>Nope</Button>
+      }
+    ],
+  };
+}
+```
+
+We also have "consumers" that use the variation provider to perform tasks. Example consumers are:
+* Rendering variations in [Storybook](https://storybook.js.org/)
+* Running in tests with [Enzyme](https://github.com/airbnb/react-component-variations-consumer-enzyme)
+* Taking screenshots with [Happo](https://happo.io/)
+* Checking for accessibility violations with [Axe](https://www.deque.com/axe/)
 
 ## Contribution Guidelines:
 


### PR DESCRIPTION
Perhaps a replacement for #7, this PR adds basic documentation about the project to the README. It's not intended to be comprehensive, and I'll be adding more documentation of providers and consumers.

@sharmilajesupaul can you take a look at this, please?